### PR TITLE
#1 Scraper interface moved to package scraper

### DIFF
--- a/project/webScraper/src/main/java/scraper/Scraper.java
+++ b/project/webScraper/src/main/java/scraper/Scraper.java
@@ -1,6 +1,7 @@
-package domain;
+package scraper;
 
 import domain.Product;
+import domain.Shop;
 import java.util.List;
 
 public interface Scraper {


### PR DESCRIPTION
Scraper doesn't belongs to package 'domain', so it was moved into a new package named 'scraper'